### PR TITLE
Fix bad state on 1st character where model != view

### DIFF
--- a/src/directives/mask.js
+++ b/src/directives/mask.js
@@ -69,6 +69,7 @@
                 var options = maskService.getOptions();
 
                 function parseViewValue(value) {
+                  var untouchedValue = value;
                   // set default value equal 0
                   value = value || '';
 
@@ -125,7 +126,7 @@
 
                     // Set validity
                     if (options.validate && controller.$dirty) {
-                      if (fullRegex.test(viewValueWithDivisors) || controller.$isEmpty(controller.$modelValue)) {
+                      if (fullRegex.test(viewValueWithDivisors) || controller.$isEmpty(untouchedValue)) {
                         controller.$setValidity('mask', true);
                       } else {
                         controller.$setValidity('mask', false);


### PR DESCRIPTION
When first entering text into the field, it's common for the viewValue to be different than the model value. 

When testing the validity of the current value, the parseViewValue function was checking whether or not the model value was empty, instead of the view value.
